### PR TITLE
ci: add support for laravel 13

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,15 +10,27 @@ jobs:
       fail-fast: true
       matrix:
         php: [8.2, 8.3, 8.4, 8.5]
-        laravel: [11.*, 12.*]
+        laravel: [11.*, 12.*, 13.*]
+        phpunit: [11.*,12.*]
         dependency-version: [prefer-lowest, prefer-stable]
         include:
           - laravel: 11.*
             testbench: 9.*
           - laravel: 12.*
             testbench: 10.*
+          - laravel: 13.*
+            testbench: 11.*
+        exclude:
+          - laravel: 11.*
+            phpunit: 12.*
+          - laravel: 12.*
+            phpunit: 12.*
+          - laravel: 13.*
+            phpunit: 11.*
+          - laravel: 13.*
+            php: 8.2
 
-    name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
+    name: P${{ matrix.php }} - L${{ matrix.laravel }} - U${{ matrix.phpunit }} - ${{ matrix.dependency-version }}
 
     steps:
       - name: Checkout code

--- a/composer.json
+++ b/composer.json
@@ -17,13 +17,13 @@
     ],
     "require": {
         "php": "^8.2",
-        "illuminate/support": "^11.0|^12.0"
+        "illuminate/support": "^11.0|^12.0|^13.0"
     },
     "require-dev": {
         "exolnet/phpcs-config": "^2.0",
         "mockery/mockery": "^1.4.3",
-        "orchestra/testbench": "^9.0|^10.0",
-        "phpunit/phpunit": "^11.5.10",
+        "orchestra/testbench": "^9.0|^10.0|^11.0",
+        "phpunit/phpunit": "^11.5.10|^12.0",
         "squizlabs/php_codesniffer": "^3.6.0"
     },
     "autoload": {


### PR DESCRIPTION
Ref #58942

This pull request updates the package to support Laravel 13 and PHPUnit 12, and adjusts the test matrix to ensure compatibility across supported versions. The main changes are grouped below:

**Laravel and PHPUnit Version Support:**

* Added support for Laravel 13 by updating the `illuminate/support` dependency in `composer.json` and adjusting the test matrix to include Laravel 13 and its compatible `orchestra/testbench` version. [[1]](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L20-R26) [[2]](diffhunk://#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fL13-R33)
* Added support for PHPUnit 12 by updating the `phpunit/phpunit` dependency in `composer.json` and including PHPUnit 12 in the test matrix. [[1]](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L20-R26) [[2]](diffhunk://#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fL13-R33)

**Test Matrix Improvements:**

* Updated `.github/workflows/tests.yml` to test all combinations of supported PHP, Laravel, and PHPUnit versions, including new exclusions to avoid incompatible combinations. The job name now reflects the PHPUnit version being tested.
* Updated `orchestra/testbench` dev dependency to include version 11 for Laravel 13 compatibility.